### PR TITLE
:sparkles: Accept single request json files

### DIFF
--- a/multi_hello.json
+++ b/multi_hello.json
@@ -1,0 +1,17 @@
+[
+        {
+                "name":"firstGreet",
+                "method":"helloworld.Greeter.SayHello",
+                "body":
+                {
+                        "name":"test"
+                }
+        },
+        {
+                "method":"helloworld.Greeter.SayHello",
+                "body":
+                {
+                        "name":"$$firstGreet.message"
+                }
+        }
+]

--- a/single_hello.json
+++ b/single_hello.json
@@ -1,0 +1,9 @@
+[
+        {
+                "method":"helloworld.Greeter.SayHello",
+                "body":
+                {
+                        "name":"my name is k0i"
+                }
+        }
+]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,5 +1,5 @@
 use crate::types::Request;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use std::{fs, path::Path};
 
 pub fn open_file<P: AsRef<Path>>(path: P) -> Result<Vec<Request>>
@@ -8,7 +8,17 @@ where
 {
     let file = fs::read_to_string(path.as_ref())
         .with_context(|| format!("Failed to open file: {:?}", path))?;
-    let reqs: Vec<Request> = serde_json::from_str(file.as_str())
-        .with_context(|| format!("Failed to parse json: {:?}", path))?;
-    Ok(reqs)
+    let reqs: Result<Vec<Request>, serde_json::error::Error> = serde_json::from_str(file.as_str());
+    match reqs {
+        Ok(r) => Ok(r),
+        _ => {
+            let req: Result<Request, serde_json::error::Error> =
+                serde_json::from_str(file.as_str());
+            if let Ok(r) = req {
+                Ok(vec![r])
+            } else {
+                bail!("Failed to parse json: {}", file)
+            }
+        }
+    }
 }


### PR DESCRIPTION


## Motivation
- This PR enables parsing a json file not only with multiple requests but a single request.
- Improve error messages to detect what causes errors more instinctively.
- Colorize output 

<img width="782" alt="Снимок экрана 2022-08-01 055158" src="https://user-images.githubusercontent.com/100127291/182044946-d248cca3-5d15-4e08-a3d2-48faa5ee50c4.png">
